### PR TITLE
Fixed exception message

### DIFF
--- a/src/TestItem.php
+++ b/src/TestItem.php
@@ -125,7 +125,7 @@ class TestItem implements Arrayable
     public function validate()
     {
         if (count($this->getDistractorCollection()->toArray()) < 3) {
-            throw new \Exception('Error processing request: An issue was encountered with the following text: ' . $this->stem . '.  Please check this file for leading and trailing spaces. No items were imported.');
+            throw new \Exception('An issue was encountered with the following text: ' . $this->stem . '.  Please check this file for leading and trailing spaces. No items were imported.');
         }
 
         if (empty($this->stem)) {


### PR DESCRIPTION
The exception message for when the test item has too many distractors had redundant text.
